### PR TITLE
Add GitHub Action to fetch external documentation

### DIFF
--- a/.github/external-docs-config.json
+++ b/.github/external-docs-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Sample Project Alpha",
+    "repo": "your-username-or-org/sample-project-alpha-docs",
+    "source_path": "docs",
+    "target_subfolder": "sample-alpha"
+  },
+  {
+    "name": "Sample Module Beta",
+    "repo": "your-username-or-org/sample-module-beta-docs",
+    "source_path": "documentation",
+    "target_subfolder": "sample-beta"
+  }
+]

--- a/.github/workflows/fetch-docs.yml
+++ b/.github/workflows/fetch-docs.yml
@@ -1,0 +1,155 @@
+name: Fetch External Documentation
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight UTC
+  push:
+    branches:
+      - main # Or your default branch
+  workflow_dispatch:
+    inputs:
+      force_run:
+        description: 'Force run (currently no special behavior)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: write # To checkout private repos (if PAT has repo scope) and push changes back to this repo
+
+jobs:
+  fetch_and_update_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Website Repository
+        uses: actions/checkout@v4
+        with:
+          path: website # Checkout main repo into a 'website' subdirectory
+          # Using a PAT is recommended for broad access and reliable push.
+          # Ensure this PAT has 'repo' scope if fetching private repos or for robust pushing.
+          token: ${{ secrets.GH_PAT_FOR_DOCS_FETCH }}
+
+      - name: Setup Git User
+        run: |
+          git config --global user.name "GitHub Actions Doc Fetcher"
+          git config --global user.email "actions-doc-fetcher@users.noreply.github.com"
+        working-directory: ./website
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Clear existing external docs and create base docs directory
+        working-directory: ./website/content
+        run: |
+          echo "Clearing and preparing docs directory..."
+          # Remove existing subdirectories that might be from the config to avoid stale content
+          # This is a basic approach; more sophisticated would be to read config and selectively delete
+          # For now, let's assume 'docs' might contain other manually added content, so we are careful
+          # A safer approach is to have a dedicated subdir like 'content/external-docs'
+          # and wipe that, then Hugo config combines them.
+          # For this draft, we'll target specific subfolders based on config later.
+          mkdir -p docs
+
+      - name: Loop through external documentation sources
+        env:
+          GH_PAT: ${{ secrets.GH_PAT_FOR_DOCS_FETCH }}
+        run: |
+          CONFIG_FILE="${{ github.workspace }}/website/.github/external-docs-config.json"
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo "Configuration file not found: $CONFIG_FILE"
+            exit 1
+          fi
+
+          echo "Processing external documentation sources from $CONFIG_FILE"
+          jq -c '.[]' $CONFIG_FILE | while read -r item; do
+            REPO_NAME=$(echo "$item" | jq -r '.name')
+            REPO_URL=$(echo "$item" | jq -r '.repo')
+            SOURCE_PATH=$(echo "$item" | jq -r '.source_path')
+            TARGET_SUBFOLDER=$(echo "$item" | jq -r '.target_subfolder') # e.g., "project-a"
+
+            echo "Fetching docs for $REPO_NAME from $REPO_URL (path: $SOURCE_PATH)"
+
+            TEMP_CHECKOUT_PATH="${{ github.workspace }}/external_tmp/$TARGET_SUBFOLDER"
+            FINAL_DOCS_PATH="${{ github.workspace }}/website/content/docs/$TARGET_SUBFOLDER"
+
+            echo "Cleaning up previous target directory: $FINAL_DOCS_PATH"
+            rm -rf "$FINAL_DOCS_PATH"
+            mkdir -p "$FINAL_DOCS_PATH"
+
+            echo "Cleaning up temporary checkout path: $TEMP_CHECKOUT_PATH"
+            rm -rf "$TEMP_CHECKOUT_PATH" # Clean before checkout
+            mkdir -p "$(dirname "$TEMP_CHECKOUT_PATH")"
+
+
+            # Checkout the specific documentation folder using sparse checkout
+            git clone --depth 1 --filter=blob:none --sparse https://x-access-token:$GH_PAT@github.com/$REPO_URL.git "$TEMP_CHECKOUT_PATH"
+            if [ $? -ne 0 ]; then
+                echo "Failed to clone $REPO_URL"
+                # Decide if to continue with other repos or fail the job
+                # For now, let's try to continue
+                continue
+            fi
+            (
+              cd "$TEMP_CHECKOUT_PATH"
+              git sparse-checkout init --cone
+              git sparse-checkout set "$SOURCE_PATH"
+              # git checkout # Ensure we are on the default branch, or specify one if needed
+            )
+            if [ $? -ne 0 ]; then
+                echo "Failed to sparse-checkout $SOURCE_PATH from $REPO_URL"
+                continue
+            fi
+
+            # Verify that the source path exists after sparse checkout
+            if [ ! -d "$TEMP_CHECKOUT_PATH/$SOURCE_PATH" ]; then
+              echo "Source path '$SOURCE_PATH' does not exist in the checkout for $REPO_NAME."
+              ls -la "$TEMP_CHECKOUT_PATH" # List contents for debugging
+              continue # Skip to the next item
+            fi
+
+            echo "Copying from $TEMP_CHECKOUT_PATH/$SOURCE_PATH to $FINAL_DOCS_PATH"
+            # Using rsync for better copying (preserves attributes, can delete extraneous files if needed)
+            # Ensure rsync is available or install it
+            sudo apt-get install -y rsync
+            rsync -av --delete "$TEMP_CHECKOUT_PATH/$SOURCE_PATH/" "$FINAL_DOCS_PATH/"
+
+            # Create a default _index.md if one doesn't exist in the copied docs
+            # This makes the folder a Hugo section.
+            if [ ! -f "$FINAL_DOCS_PATH/_index.md" ] && [ ! -f "$FINAL_DOCS_PATH/index.md" ]; then
+              echo "Creating default _index.md for $TARGET_SUBFOLDER as it's missing in the source."
+              cat <<EOL > "$FINAL_DOCS_PATH/_index.md"
+          ---
+          title: "$REPO_NAME"
+          type: "docs" # Important for Hextra to recognize this as a documentation section
+          weight: 10 # Optional: for ordering in the sidebar
+          ---
+          This section contains documentation for $REPO_NAME, automatically fetched from the $REPO_URL repository.
+          EOL
+            fi
+
+            echo "Successfully processed $REPO_NAME"
+          done
+          echo "Finished processing all sources."
+
+      - name: Commit and Push Documentation Changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Chore: Update external documentation from configured sources"
+          repository: website # Path to the checked out website repo relative to GITHUB_WORKSPACE
+          # commit_options: '--no-verify' # Optional
+          file_pattern: 'content/docs/**/*.*' # Pattern of files to look for changes
+          # push_options: '--force' # Use with caution
+          # skip_dirty_check: false # Default
+          # skip_fetch: true # Default
+          # skip_checkout: true # Default
+          # disable_globbing: false # Default
+          # create_branch: false # Default
+          commit_user_name: "GitHub Actions Doc Fetcher" # Ensure this matches git config
+          commit_user_email: "actions-doc-fetcher@users.noreply.github.com" # Ensure this matches git config
+          commit_author: "GitHub Actions Doc Fetcher <actions-doc-fetcher@users.noreply.github.com>" # Ensure this matches git config
+
+      - name: Clean up temporary external checkouts
+        if: always() # Run even if previous steps fail
+        run: |
+          echo "Cleaning up temporary directory ${{ github.workspace }}/external_tmp"
+          rm -rf "${{ github.workspace }}/external_tmp"
+          echo "Cleanup complete."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# Hugo Website with Hextra Theme
+
+This repository hosts a Hugo website using the Hextra theme.
+
+## Features
+
+### Automated External Documentation Fetching
+
+This site is configured with a GitHub Actions workflow to automatically fetch documentation from other repositories and integrate it into the `content/docs/` section of this website. This allows for a centralized documentation portal built from distributed sources.
+
+**Workflow File:** `.github/workflows/fetch-docs.yml`
+
+#### How it Works
+
+The workflow performs the following steps:
+
+1.  **Triggers**:
+    *   Runs on a daily schedule (`cron: '0 0 * * *'`).
+    *   Runs on pushes to the `main` branch of this repository.
+    *   Can be manually triggered via the GitHub Actions UI (`workflow_dispatch`).
+
+2.  **Checkout**:
+    *   Checks out this website repository into a `website/` subdirectory in the GitHub Actions runner.
+
+3.  **Configuration**:
+    *   Reads a list of external documentation sources from the `.github/external-docs-config.json` file.
+
+4.  **Processing Each Source**:
+    *   For each entry in the configuration file:
+        *   Cleans any previous version of that source's documentation from `website/content/docs/`.
+        *   Uses `git clone --sparse` to efficiently check out only the specified documentation folder from the remote repository. This is done into a temporary directory.
+        *   Copies the fetched documentation files into the appropriate subfolder under `website/content/docs/` using `rsync --delete` (which ensures stale files are removed).
+        *   If an `_index.md` (or `index.md`) is not present in the root of the fetched documentation for a source, a basic one is generated to ensure Hugo recognizes it as a section. This generated `_index.md` will have `type: "docs"` in its front matter, which is suitable for the Hextra theme.
+
+5.  **Commit and Push**:
+    *   If any changes are detected within `website/content/docs/`, the workflow commits these changes using a dedicated Git user ("GitHub Actions Doc Fetcher").
+    *   The changes are then pushed back to the `main` branch of this repository.
+
+6.  **Cleanup**:
+    *   Removes the temporary directory used for checking out external repositories.
+
+#### Configuration Steps
+
+To add or modify the external documentation sources, follow these steps:
+
+1.  **Personal Access Token (PAT)**:
+    *   Ensure a GitHub Personal Access Token (PAT) is available and configured as a secret in this repository.
+    *   Go to your repository's `Settings > Secrets and variables > Actions`.
+    *   Create a new repository secret named `GH_PAT_FOR_DOCS_FETCH`.
+    *   The PAT must have the `repo` scope. This is necessary for:
+        *   Cloning other repositories (especially if they are private).
+        *   Pushing the aggregated documentation back to this (the website) repository.
+    *   It's recommended to use a PAT from a dedicated machine user or a user whose contributions you want associated with these automated updates.
+
+2.  **Edit Configuration File**:
+    *   Open the `.github/external-docs-config.json` file in this repository.
+    *   This file is a JSON array of objects, where each object defines one external documentation source.
+    *   To add a new source, add a new JSON object to the array:
+        ```json
+        {
+          "name": "My Awesome Project Docs",
+          "repo": "your-github-username-or-org/my-awesome-project",
+          "source_path": "docs/latest",
+          "target_subfolder": "my-awesome-project"
+        }
+        ```
+    *   **Field Explanations**:
+        *   `"name"`: (String) A human-readable name for the documentation source. This will be used as the title in the auto-generated `_index.md` if the source doesn't provide its own.
+        *   `"repo"`: (String) The GitHub repository slug in the format `owner/repository-name` from which to fetch the documentation.
+        *   `"source_path"`: (String) The specific path/folder *within the external repository* that contains the Markdown documentation files you want to include (e.g., `docs`, `guides/content`, `api-docs`).
+        *   `"target_subfolder"`: (String) The name of the subfolder that will be created under `content/docs/` in *this* website repository. The fetched documentation will be placed here (e.g., `my-awesome-project`, `api-reference-v1`). This path should be unique for each source.
+
+3.  **Commit Changes**:
+    *   Commit and push your changes to `external-docs-config.json` to the `main` branch.
+    *   The workflow will automatically trigger on this push and attempt to fetch the newly configured documentation.
+
+#### Manual Trigger
+
+You can manually trigger the workflow:
+1.  Go to the "Actions" tab of your repository.
+2.  Select the "Fetch External Documentation" workflow from the list.
+3.  Click the "Run workflow" dropdown.
+4.  You can choose the branch (typically `main`) and click "Run workflow".
+
+#### Hugo and Hextra Theme
+
+This website uses Hugo as the static site generator and the Hextra theme. The fetched documentation should be standard Markdown. The Hextra theme will handle rendering it. Ensure that the `_index.md` files (either fetched or auto-generated) for each documentation section are configured appropriately if you need specific Hextra features like sidebar icons, custom ordering (weights), etc. The auto-generated `_index.md` includes `type: "docs"` which is standard for Hextra documentation sections.
+
+---
+
+*This README and the automated documentation fetching workflow were set up by Jules, your AI software engineering assistant.*


### PR DESCRIPTION
Implements a GitHub Actions workflow that automatically fetches documentation from specified external repositories.

Key features:
- Workflow is triggered on schedule, push to main, or manually.
- Configuration of source repositories is managed via a JSON file (`.github/external-docs-config.json`).
- Uses sparse checkout for efficient fetching of only documentation folders.
- Copies fetched content into `content/docs/` under respective subfolders.
- Automatically generates a Hextra-compatible `_index.md` for new sections if one doesn't exist in the source.
- Commits and pushes changes to the website repository if updates are found.
- Includes documentation in README.md for setup and configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated integration of external documentation from multiple repositories into the website, updated daily or on demand.
* **Documentation**
  * Added a README with setup instructions and workflow details for managing external documentation sources.
* **Chores**
  * Introduced configuration and workflow files to support external documentation fetching and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->